### PR TITLE
Improve font family for zh-TW locale

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Translations.config
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Translations.config
@@ -8,7 +8,7 @@
     <Editor_FontFamily>Consolas,Microsoft Yahei UI,Microsoft Yahei,SimSun</Editor_FontFamily>
   </zh-CN>
   <zh-TW>
-    <Editor_FontFamily>Segoe UI,Microsoft JhengHei UI,Microsoft JhengHei,SimSun</Editor_FontFamily>
+    <Editor_FontFamily>Consolas,Microsoft JhengHei UI,Microsoft JhengHei,MingLiU</Editor_FontFamily>
   </zh-TW>
   <ja-JP>
     <Editor_FontFamily>Consolas,Meiryo UI,MS UI Gothic,MS Gothic</Editor_FontFamily>


### PR DESCRIPTION
zh-TW locale generally does not use SimSun, use MingLiU instead.