### PR TITLE
Replacing “Windows Store” in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ I am aware that several alternatives are already available on the Internet (e.g.
  [What are the differences between `.msi`, `.zip`, nightly and Store versions?](https://github.com/xupefei/QuickLook/wiki/Difference-between-distributions)
 
  1. Download from one of the following
-    * Windows Store (for Windows 10 users) <a href="https://www.microsoft.com/store/apps/9nv4bs3l1h4s?ocid=badge" target="_blank"><img src="https://assets.windowsphone.com/13484911-a6ab-4170-8b7e-795c1e8b4165/English_get_L_InvariantCulture_Default.png" width="80px" alt="Store Link" /></a> 
+    * Microsoft Store (for Windows 10 users) <a href="https://www.microsoft.com/store/apps/9nv4bs3l1h4s?ocid=badge" target="_blank"><img src="https://assets.windowsphone.com/13484911-a6ab-4170-8b7e-795c1e8b4165/English_get_L_InvariantCulture_Default.png" width="80px" alt="Store Link" /></a> 
     * Installer or portable archive of the stable version from [GitHub Release](https://github.com/xupefei/QuickLook/releases) 
     * Nightly builds from [AppVeyor](https://ci.appveyor.com/project/xupefei/quicklook/build/artifacts)
  2. Run `QuickLook.exe`
  3. Select a file/folder on the Desktop / in a File Explorer window / in an Open- or Save-File dialog
  4. Press <kbd>Spacebar</kbd>
  5. Select another file/folder in the same manner
- 6. When you're done, click on the `❎` button, or press <kbd>Spacebar</kbd> again
+ 6. When you're done, click on the `⨉` button, or press <kbd>Spacebar</kbd> again
 
 ### Hotkeys and buttons
 


### PR DESCRIPTION
Microsoft renamed Windows Store to Microsoft Store, this following that.