### PR TITLE
Use correct registry key for installer

### DIFF
--- a/QuickLook.Installer/Product.wxs
+++ b/QuickLook.Installer/Product.wxs
@@ -31,7 +31,7 @@
           <RemoveFolder Id="ProgramMenuFolder" On="uninstall" />
           <RegistryValue
             Root="HKCU"
-            Key="Software/QuickLook"
+            Key="Software\QuickLook"
             Name="installed"
             Type="integer"
             Value="1"
@@ -48,7 +48,7 @@
           <RemoveFolder Id="DesktopFolder" On="uninstall" />
           <RegistryValue
             Root="HKCU"
-            Key="Software/QuickLook"
+            Key="Software\QuickLook"
             Name="installed"
             Type="integer"
             Value="1"


### PR DESCRIPTION
This is probably the simplest pull request there is. The installer creates a registry key called Software/QuickLook, although it should be Software\QuickLook to respect the Windows syntax.