### PR TITLE
Improve German translations

### DIFF
--- a/QuickLook/Translations.config
+++ b/QuickLook/Translations.config
@@ -192,19 +192,20 @@
     <UI_FontFamily>Segoe UI</UI_FontFamily>
     <APP_START>QuickLook läuft im Hintergrund.</APP_START>
     <APP_SECOND>QuickLook läuft bereits im Hintergrund</APP_SECOND>
-    <MW_BrowseFolder>Durchsuchen {0}</MW_BrowseFolder>
-    <MW_Open>Öffnen {0}</MW_Open>
+    <APP_SECOND_TEXT>QuickLook ermöglicht eine schnelle Vorschau auf bestimmte Dateitypen durch das Drücken der Leertaste während es ausgewählt ist.</APP_SECOND_TEXT>
+    <MW_BrowseFolder>{0} durchsuchen</MW_BrowseFolder>
+    <MW_Open>{0} öffnen</MW_Open>
     <MW_OpenWith>Öffnen mit {0}</MW_OpenWith>
-    <MW_Run>Ausführen {0}</MW_Run>
-    <Icon_RunAtStartup>Beim Systemstart &amp; ausführen</Icon_RunAtStartup>
+    <MW_Run>{0} ausführen</MW_Run>
+    <Icon_RunAtStartup>Beim Systemstart &amp;ausführen</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
-    <Icon_CheckUpdate>Suche nach &amp;Updates...</Icon_CheckUpdate>
+    <Icon_CheckUpdate>Nach &amp;Updates suchen...</Icon_CheckUpdate>
     <Icon_Quit>&amp;Beenden</Icon_Quit>
     <Update_NoUpdate>Sie haben die neueste Version..</Update_NoUpdate>
     <Update_Found>QuickLook {0} ist verfügbar. Klicken Sie hier, um die Downloadseite zu öffnen.</Update_Found>
     <Update_Error>Beim Suchen nach Updates ist ein Fehler aufgetreten: {0}</Update_Error>
     <InfoPanel_LastModified>Zuletzt geändert am {0}</InfoPanel_LastModified>
-    <InfoPanel_DriveSize>Speicher {0}, {1} verfügbar</InfoPanel_DriveSize>
+    <InfoPanel_DriveSize>{1} frei von {0}</InfoPanel_DriveSize>
     <InfoPanel_Folder>{0} Ordner</InfoPanel_Folder>
     <InfoPanel_Folders>{0} Ordner</InfoPanel_Folders>
     <InfoPanel_File>{0} Datei</InfoPanel_File>


### PR DESCRIPTION
- Added translation for `APP_SECOND_TEXT`
- Made some translations sound more natural (and also grammatically correct in some cases)
- Fixed issue with `Icon_RunAtStartup`
- Updated `InfoPanel_DriveSize` to match how Windows displays it itself in German (literally in English `{1} free of {0}`)
![image](https://user-images.githubusercontent.com/9491603/37258394-bcf87094-2577-11e8-81e1-61c2acde85a9.png)
